### PR TITLE
Restrict airtraffic

### DIFF
--- a/addons/ambient_aircraft/config.cpp
+++ b/addons/ambient_aircraft/config.cpp
@@ -164,6 +164,20 @@ class CfgVehicles {
                 typeName = "STRING";
                 defaultValue = "[2, 4, 1]";
             };
+			class includeZones: Edit {
+                property = "irn_amb_airtraffic_includeZones";
+                displayName = "inclusion markers";
+				tooltip = "Only spawn flybys for players that are in these marker areas";	// Tooltip description
+                typeName = "STRING";
+                defaultValue = "['airtraffic_include_0']";
+            };
+			class excludeZones: Edit {
+                property = "irn_amb_airtraffic_excludeZones";
+                displayName = "exclusion markers";
+				tooltip = "Only spawn flybys for players that are not in these marker areas";	// Tooltip description
+                typeName = "STRING";
+                defaultValue = "['airtraffic_exclude_0']";
+            };
 			class squadSize: Edit {
                 property = "irn_amb_airtraffic_squadsize";
                 displayName = "squad size array";

--- a/addons/ambient_aircraft/config.cpp
+++ b/addons/ambient_aircraft/config.cpp
@@ -160,23 +160,9 @@ class CfgVehicles {
 			class weights: Edit {
                 property = "irn_amb_airtraffic_weights";
                 displayName = "class weights array";
-				tooltip = "How often to spawn this plane type compared to the others.";	// Tooltip description
+				tooltip = "How often to spawn this plane type compared to the others. one entry per plane class";	// Tooltip description
                 typeName = "STRING";
                 defaultValue = "[2, 4, 1]";
-            };
-			class includeZones: Edit {
-                property = "irn_amb_airtraffic_includeZones";
-                displayName = "inclusion markers";
-				tooltip = "Only spawn flybys for players that are in these marker areas";	// Tooltip description
-                typeName = "STRING";
-                defaultValue = "['airtraffic_include_0']";
-            };
-			class excludeZones: Edit {
-                property = "irn_amb_airtraffic_excludeZones";
-                displayName = "exclusion markers";
-				tooltip = "Only spawn flybys for players that are not in these marker areas";	// Tooltip description
-                typeName = "STRING";
-                defaultValue = "['airtraffic_exclude_0']";
             };
 			class squadSize: Edit {
                 property = "irn_amb_airtraffic_squadsize";
@@ -216,7 +202,20 @@ class CfgVehicles {
 					class ind	{ name = "Independent"; value = 3; };
 				};
 			};
-			
+			class includeZones: Edit {
+                property = "irn_amb_airtraffic_includeZones";
+                displayName = "inclusion markers";
+				tooltip = "Only spawn flybys for players that are in these marker areas. array of marker names";	// Tooltip description
+                typeName = "STRING";
+                defaultValue = "['airtraffic_include_0']";
+            };
+			class excludeZones: Edit {
+                property = "irn_amb_airtraffic_excludeZones";
+                displayName = "exclusion markers";
+				tooltip = "Only spawn flybys for players that are not in these marker areas. array of marker names";	// Tooltip description
+                typeName = "STRING";
+                defaultValue = "['airtraffic_exclude_0']";
+            };
 			class ModuleDescription: ModuleDescription {};
 		};
 		class ModuleDescription: ModuleDescription {

--- a/addons/ambient_aircraft/functions/fnc_ambientAirtraffic.sqf
+++ b/addons/ambient_aircraft/functions/fnc_ambientAirtraffic.sqf
@@ -93,7 +93,7 @@ if !(_squadronSize isEqualTypeArray (_classes apply {1})) exitWith {
 };
 
 {	//push relevant parameters into anchor object namespace
-	diag_log ["pushing var:",_x#0,_x#1];
+	// diag_log ["pushing var:",_x#0,_x#1];
 	_anchor setVariable ["irn_amb_planes_"+_x#0,_x#1];
 } forEach [
 	["classes",_classes],
@@ -160,11 +160,11 @@ if !(_squadronSize isEqualTypeArray (_classes apply {1})) exitWith {
 
 			// player NOT inside INCLUSION ZONE => abort
 			if (_includeZones isNotEqualTo [] && !(true in (_includeZones apply { _p inArea _x }))) exitWith {
-				diag_log ["player not in inclusion zone"];
+				// diag_log ["player not in inclusion zone"];
 			};
 			// player inside EXCLUSION ZONE => abort
 			if (_excludeZones isNotEqualTo [] && (true in (_excludeZones apply { _p inArea _x }))) exitWith {
-				diag_log ["player is in EXCLUSION ZONE"];
+				// diag_log ["player is in EXCLUSION ZONE"];
 			};
 
 			_class = _classes selectRandomWeighted _weights;		

--- a/addons/ambient_aircraft/functions/fnc_ambientAirtrafficModule.sqf
+++ b/addons/ambient_aircraft/functions/fnc_ambientAirtrafficModule.sqf
@@ -4,39 +4,45 @@ _logic = param [0, objNull, [objNull]];
 _units = param [1, [], [[]]];
 _activated = param [2, true, [true]];
 if (!isServer) exitWith {};	//is this necessary?
-// module specific behavior. Function can extract arguments from logic and use them.
-if (_activated) then {
-	//parse values
-    _planeClass = parseSimpleArray (_logic getVariable ["planeClass", "['I_Plane_Fighter_03_dynamicloadout_F']"]);
-	_weights = parseSimpleArray (_logic getVariable ["weights", "[2]"]);	//relative weights
-	_squadSize = parseSimpleArray (_logic getVariable ["squadsize", "[2]"]);	//maximum squad sizes
 
-    _includeZones = parseSimpleArray (_logic getVariable ["includeZones", "[]"]) select { _x in allMapMarkers};
-    _excludeZones = parseSimpleArray (_logic getVariable ["excludeZones", "[]"]) select { _x in allMapMarkers};
+//parse values
+_planeClass = parseSimpleArray (_logic getVariable ["planeClass", "['I_Plane_Fighter_03_dynamicloadout_F']"]);
+_weights = parseSimpleArray (_logic getVariable ["weights", "[2]"]);	//relative weights
+_squadSize = parseSimpleArray (_logic getVariable ["squadsize", "[2]"]);	//maximum squad sizes
 
-    assert ((count _planeClass) == (count _weights));
-	assert ((count _planeClass) == (count _squadSize));
-	_timeout = _logic getVariable ["timeout", 10];	//minutes
-    _duration = _logic getVariable ["duration", 30];	//minutes
-    _sideId = _logic getVariable ["side", 0];
-    _side = civilian;    
-    switch (_sideId) do {
-        case 1: {
-            _side = blufor;
-        };
-        case 2: {
-            _side = opfor;
-        };
-        case 3: {
-            _side = independent;
-        };
-        default {
-            _side = civilian;
-        };
+_includeZones = parseSimpleArray (_logic getVariable ["includeZones", "[]"]) select { _x in allMapMarkers};
+_excludeZones = parseSimpleArray (_logic getVariable ["excludeZones", "[]"]) select { _x in allMapMarkers};
+
+if ((count _planeClass) != (count _weights)) then {
+    ERROR_MSG("airtraffic eden module parsing error: weights array has wrong number of elements.");
+};
+if ((count _planeClass) != (count _squadSize)) then {
+    ERROR_MSG("airtraffic eden module parsing error: squads array has wrong number of elements.");
+};
+
+_timeout = _logic getVariable ["timeout", 10];	//minutes
+_duration = _logic getVariable ["duration", 30];	//minutes
+_sideId = _logic getVariable ["side", 0];
+_side = civilian;    
+switch (_sideId) do {
+    case 1: {
+        _side = blufor;
     };
+    case 2: {
+        _side = opfor;
+    };
+    case 3: {
+        _side = independent;
+    };
+    default {
+        _side = civilian;
+    };
+};
 
-	_params = [_timeout,_planeClass,_weights,_squadSize,_side,_duration, getPos _logic, _includeZones, _excludeZones];
-	diag_log ["module airtraffic with values:","params",_params];
+_params = [_timeout,_planeClass,_weights,_squadSize,_side,_duration, getPos _logic, _includeZones, _excludeZones];
+diag_log ["module airtraffic with values:","params",_params];
+
+if (_activated) then {
 	_params call FUNC(ambientAirtraffic);
 };
 true

--- a/addons/ambient_aircraft/functions/fnc_ambientAirtrafficModule.sqf
+++ b/addons/ambient_aircraft/functions/fnc_ambientAirtrafficModule.sqf
@@ -10,6 +10,10 @@ if (_activated) then {
     _planeClass = parseSimpleArray (_logic getVariable ["planeClass", "['I_Plane_Fighter_03_dynamicloadout_F']"]);
 	_weights = parseSimpleArray (_logic getVariable ["weights", "[2]"]);	//relative weights
 	_squadSize = parseSimpleArray (_logic getVariable ["squadsize", "[2]"]);	//maximum squad sizes
+
+    _includeZones = parseSimpleArray (_logic getVariable ["includeZones", "[]"]) select { _x in allMapMarkers};
+    _excludeZones = parseSimpleArray (_logic getVariable ["excludeZones", "[]"]) select { _x in allMapMarkers};
+
     assert ((count _planeClass) == (count _weights));
 	assert ((count _planeClass) == (count _squadSize));
 	_timeout = _logic getVariable ["timeout", 10];	//minutes
@@ -31,7 +35,7 @@ if (_activated) then {
         };
     };
 
-	_params = [_timeout,_planeClass,_weights,_squadSize,_side,_duration, getPos _logic];
+	_params = [_timeout,_planeClass,_weights,_squadSize,_side,_duration, getPos _logic, _includeZones, _excludeZones];
 	diag_log ["module airtraffic with values:","params",_params];
 	_params call FUNC(ambientAirtraffic);
 };


### PR DESCRIPTION
airtraffic module allows user to set exclusion zones and inclusion zones
exclusion: players inside that zone will not receive flybys
inclusion: only players inside that zone will receive flybys

pass as array of marker names
markers can be non-existent in map, will be filtered.